### PR TITLE
Clean up external project for packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,16 @@ project(fmilibrary_vendor)
 find_package(ament_cmake REQUIRED)
 
 include(ExternalProject)
-externalproject_add(FMILibraryProject
+set(fmilibrary_version 2.2.3)
+externalproject_add(FMILibraryProject-${fmilibrary_version}
   GIT_REPOSITORY https://github.com/modelon-community/fmi-library.git
-  GIT_TAG 2.2.3
+  GIT_TAG ${fmilibrary_version}
+  GIT_CONFIG advice.detachedHead=false
+  # Suppress git update due to https://gitlab.kitware.com/cmake/cmake/-/issues/16419
+  UPDATE_COMMAND ""
   TIMEOUT 60
 )
-externalproject_get_property(FMILibraryProject INSTALL_DIR)
+externalproject_get_property(FMILibraryProject-${fmilibrary_version} INSTALL_DIR)
 set(FMILibraryProject_INCLUDE_DIR "${INSTALL_DIR}/src/install/include")
 set(FMILibraryProject_LIB_DIR "${INSTALL_DIR}/src/install/lib")
 


### PR DESCRIPTION
A quirk of the way CMake handles external projects that use git is that each time the target is evaluated, an update step is performed to make sure the sources are fresh. Unfortunately, this causes the external project's build and install steps to be re-evaluated as well, even if the git update didn't actually change anything.

When this package is processed, it is first built, and then installed with a separate invocation by the build tool. Because of the quirk, the external project is re-built during the installation phase. In most circumstances, the binaries built in the prior invocation are deemed adequate and no re-compilation is performed.

Unfortunately, this wreaks havoc when the installation invocation uses DESTDIR, which is the case for the debian and RPM builds on the buildfarm. The DESTDIR environment variable affects the external project's installation into the staging directory, and you end up with a bunch of extra files getting installed by the debian into `/tmp`, which is certainly not right.

What we've been doing in the other vendor packages in ROS 2 is suppressing the update step so that CMake doesn't attempt to re-build the external project during the installation phase at all. This has the side effect that changing the GIT_TAG doesn't cause the external project to invoke git to pull a new version of the package, so to work around that, we've been embedding the version number in the name of the external project, which will obviously result in a new build when the target git tag changes.

This should resolve the build error we're seeing for RHEL 8 on the buildfarm: https://build.ros2.org/view/Rbin_rhel_el864/job/Rbin_rhel_el864__fmilibrary_vendor__rhel_8_x86_64__binary/